### PR TITLE
Finalize the logger instance

### DIFF
--- a/src/main/java/arekkuusu/solar/common/Solar.java
+++ b/src/main/java/arekkuusu/solar/common/Solar.java
@@ -45,7 +45,7 @@ public class Solar {
 	public static IProxy PROXY;
 	@Instance
 	public static Solar INSTANCE;
-	public static Logger LOG = LogManager.getLogger(LibMod.MOD_NAME);
+	public static final Logger LOG = LogManager.getLogger(LibMod.MOD_NAME);
 
 	static {
 		FluidRegistry.enableUniversalBucket();


### PR DESCRIPTION
This helps defend against malicious software from changing the logger instance to something harmful, such as a logger with the name "haha butts".

Note that this does not completely disallow the changing of this value, that would require a hard dependency on EvilNotchLib to solve.