### PR TITLE
Finalize mod class, encapsulate proxy, migrate to Mod$InstanceFactory

### DIFF
--- a/src/main/java/arekkuusu/solar/common/Solar.java
+++ b/src/main/java/arekkuusu/solar/common/Solar.java
@@ -18,15 +18,14 @@ import arekkuusu.solar.common.proxy.IProxy;
 import arekkuusu.solar.common.theorem.ModTheorems;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.Mod.InstanceFactory;
 import net.minecraftforge.fml.common.SidedProxy;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.network.NetworkRegistry;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
-import static net.minecraftforge.fml.common.Mod.EventHandler;
-import static net.minecraftforge.fml.common.Mod.Instance;
 
 /**
  * Created by <Arekkuusu> on 21/06/2017.
@@ -39,21 +38,31 @@ import static net.minecraftforge.fml.common.Mod.Instance;
 	dependencies = "required-after:mirror;",
 	acceptedMinecraftVersions = "[1.12.2]"
 )
-public class Solar {
+public final class Solar {
 
 	@SidedProxy(clientSide = LibMod.CLIENT_PROXY, serverSide = LibMod.SERVER_PROXY)
-	public static IProxy PROXY;
-	@Instance
-	public static Solar INSTANCE;
+	private static IProxy proxy;
+	private static final Solar INSTANCE = new Solar();
 	public static final Logger LOG = LogManager.getLogger(LibMod.MOD_NAME);
 
 	static {
 		FluidRegistry.enableUniversalBucket();
 	}
 
+	private Solar() {}
+
+	public static IProxy getProxy() {
+		return proxy;
+	}
+
+	@InstanceFactory
+	public static Solar getInstance() {
+		return INSTANCE;
+	}
+
 	@EventHandler
 	public void preInit(FMLPreInitializationEvent event) {
-		PROXY.preInit(event);
+		proxy.preInit(event);
 		WorldQuantumData.init(event.getAsmData());
 		PacketHandler.init();
 		ModCapability.init();
@@ -64,7 +73,7 @@ public class Solar {
 
 	@EventHandler
 	public void init(FMLInitializationEvent event) {
-		PROXY.init(event);
+		proxy.init(event);
 		NetworkRegistry.INSTANCE.registerGuiHandler(this, new GuiHandler());
 	}
 }

--- a/src/main/java/arekkuusu/solar/common/block/BlockBlinker.java
+++ b/src/main/java/arekkuusu/solar/common/block/BlockBlinker.java
@@ -142,7 +142,7 @@ public class BlockBlinker extends BlockBaseFacing {
 					.asImmutable()
 					.multiply(speed)
 					.rotate(x.multiply(z));
-			Solar.PROXY.spawnMute(world, back, speedVec, 60, 2.5F, active ? 0x49FFFF : 0xFFFFFF, Light.GLOW);
+			Solar.getProxy().spawnMute(world, back, speedVec, 60, 2.5F, active ? 0x49FFFF : 0xFFFFFF, Light.GLOW);
 		}
 	}
 

--- a/src/main/java/arekkuusu/solar/common/block/BlockDifferentiator.java
+++ b/src/main/java/arekkuusu/solar/common/block/BlockDifferentiator.java
@@ -65,7 +65,7 @@ public class BlockDifferentiator extends BlockBaseFacing {
 			if(found.getBlock() == ModBlocks.DIFFERENTIATOR_INTERCEPTOR && found.getValue(BlockDirectional.FACING) == facing) {
 				Vector3 offset = new Vector3.WrappedVec3i(facing.getDirectionVec()).asImmutable();
 				Vector3 from = new Vector3.WrappedVec3i(pos).asImmutable().add(0.5D).offset(offset, -0.19);
-				Solar.PROXY.spawnBeam(world, from, offset, distance + 0.7F, 36, 0.75F, 0xFF0303);
+				Solar.getProxy().spawnBeam(world, from, offset, distance + 0.7F, 36, 0.75F, 0xFF0303);
 				break;
 			}
 		}

--- a/src/main/java/arekkuusu/solar/common/block/BlockDilaton.java
+++ b/src/main/java/arekkuusu/solar/common/block/BlockDilaton.java
@@ -136,7 +136,7 @@ public class BlockDilaton extends BlockBaseFacing {
 						.asImmutable()
 						.multiply(speed)
 						.rotate(x.multiply(z));
-				Solar.PROXY.spawnMute(world, posVec, speedVec, 60, 2F, powered ? 0x49FFFF : 0xFF0303, Light.GLOW);
+				Solar.getProxy().spawnMute(world, posVec, speedVec, 60, 2F, powered ? 0x49FFFF : 0xFF0303, Light.GLOW);
 			}
 		}
 	}

--- a/src/main/java/arekkuusu/solar/common/block/BlockElectron.java
+++ b/src/main/java/arekkuusu/solar/common/block/BlockElectron.java
@@ -97,9 +97,9 @@ public class BlockElectron extends BlockBase {
 			for(int i = 0; i < 1 + world.rand.nextInt(3); i++) {
 				Vector3 from = Vector3.Center().add(pos.getX(), pos.getY(), pos.getZ());
 				Vector3 to = Vector3.rotateRandom().add(from);
-				Solar.PROXY.spawnArcDischarge(world, from, to, 4, 0.25F, 15, 0x5194FF, true, true);
+				Solar.getProxy().spawnArcDischarge(world, from, to, 4, 0.25F, 15, 0x5194FF, true, true);
 			}
-			Solar.PROXY.playSound(world, pos, SolarSounds.SPARK, SoundCategory.BLOCKS, 0.05F);
+			Solar.getProxy().playSound(world, pos, SolarSounds.SPARK, SoundCategory.BLOCKS, 0.05F);
 		}
 	}
 

--- a/src/main/java/arekkuusu/solar/common/block/BlockHyperConductor.java
+++ b/src/main/java/arekkuusu/solar/common/block/BlockHyperConductor.java
@@ -80,7 +80,7 @@ public class BlockHyperConductor extends BlockBase {
 		Vector3 origin = Vector3.Center().add(pos.getX(), pos.getY(), pos.getZ());
 		for(EnumFacing facing : EnumFacing.values()) {
 			Vector3 vec = new Vector3.WrappedVec3i(facing.getDirectionVec()).asImmutable().multiply(0.025D);
-			Solar.PROXY.spawnSquared(world, origin, vec, 40, 4F, 0xFFFFFF);
+			Solar.getProxy().spawnSquared(world, origin, vec, 40, 4F, 0xFFFFFF);
 		}
 	}
 

--- a/src/main/java/arekkuusu/solar/common/block/BlockImbuedQuartz.java
+++ b/src/main/java/arekkuusu/solar/common/block/BlockImbuedQuartz.java
@@ -39,7 +39,7 @@ public class BlockImbuedQuartz extends BlockBase {
 	public void randomDisplayTick(IBlockState state, World world, BlockPos pos, Random rand) {
 		for(int i = 0; i < 1 + rand.nextInt(4); i++) {
 			Vector3 posVec = new Vector3.WrappedVec3i(pos).asImmutable().add(Math.random(), Math.random(), Math.random());
-			Solar.PROXY.spawnSpeck(world, posVec, Vector3.rotateRandom().multiply(0.01D), 45, rand.nextFloat(), (int) (Math.random() * 0x1000000), GlowTexture.GLOW);
+			Solar.getProxy().spawnSpeck(world, posVec, Vector3.rotateRandom().multiply(0.01D), 45, rand.nextFloat(), (int) (Math.random() * 0x1000000), GlowTexture.GLOW);
 		}
 	}
 

--- a/src/main/java/arekkuusu/solar/common/block/BlockLumenCompressor.java
+++ b/src/main/java/arekkuusu/solar/common/block/BlockLumenCompressor.java
@@ -79,12 +79,12 @@ public class BlockLumenCompressor extends BlockBaseFacing {
 						.multiply(speed)
 						.rotate(x.multiply(z));
 				Vector3 posVec = back.add(Vector3.rotateRandom().multiply(0.2D));
-				Solar.PROXY.spawnMute(world, posVec, speedVec, 45, 1F, 0xFFE077, Light.GLOW);
+				Solar.getProxy().spawnMute(world, posVec, speedVec, 45, 1F, 0xFFE077, Light.GLOW);
 			}
 			for(int i = 0; i < 3; i++) {
 				double speed = 0.005D + rand.nextDouble() * 0.015D;
 				Vector3 speedVec = new Vector3.WrappedVec3i(facing.getDirectionVec()).asImmutable().multiply(speed);
-				Solar.PROXY.spawnMute(world, back, speedVec, 45, 2F, 0xFFE077, Light.GLOW);
+				Solar.getProxy().spawnMute(world, back, speedVec, 45, 2F, 0xFFE077, Light.GLOW);
 			}
 		}
 	}

--- a/src/main/java/arekkuusu/solar/common/block/BlockNeutronBattery.java
+++ b/src/main/java/arekkuusu/solar/common/block/BlockNeutronBattery.java
@@ -124,8 +124,8 @@ public class BlockNeutronBattery extends BlockBaseFacing {
 			);
 			double speed = 0.005D + 0.005D * rand.nextDouble();
 			Vector3 speedVec = Vector3.rotateRandom().multiply(speed);
-			Solar.PROXY.spawnMute(world, posVec, speedVec, 30, 2F, capacitor.color, Light.GLOW);
-			Solar.PROXY.spawnMute(world, vec.add(0.5D), facingVec.multiply(0.02D), 100, 2F, capacitor.color, Light.GLOW);
+			Solar.getProxy().spawnMute(world, posVec, speedVec, 30, 2F, capacitor.color, Light.GLOW);
+			Solar.getProxy().spawnMute(world, vec.add(0.5D), facingVec.multiply(0.02D), 100, 2F, capacitor.color, Light.GLOW);
 		}
 	}
 

--- a/src/main/java/arekkuusu/solar/common/block/BlockPholarizer.java
+++ b/src/main/java/arekkuusu/solar/common/block/BlockPholarizer.java
@@ -79,7 +79,7 @@ public class BlockPholarizer extends BlockBaseFacing {
 					.asImmutable()
 					.multiply(speed)
 					.rotate(x.multiply(z));
-			Solar.PROXY.spawnMute(world, posVec.add(randVec), speedVec, 45, 0.5F, 0x29FF75, Light.GLOW);
+			Solar.getProxy().spawnMute(world, posVec.add(randVec), speedVec, 45, 0.5F, 0x29FF75, Light.GLOW);
 		}
 	}
 

--- a/src/main/java/arekkuusu/solar/common/block/BlockQelaion.java
+++ b/src/main/java/arekkuusu/solar/common/block/BlockQelaion.java
@@ -143,7 +143,7 @@ public class BlockQelaion extends BlockBase {
 							.asImmutable()
 							.multiply(speed)
 							.rotate(x.multiply(z));
-					Solar.PROXY.spawnMute(world, posVec, speedVec, 60, 2F, on ? 0x49FFFF : 0xFF0303, Light.GLOW);
+					Solar.getProxy().spawnMute(world, posVec, speedVec, 60, 2F, on ? 0x49FFFF : 0xFF0303, Light.GLOW);
 				}
 			}
 		});

--- a/src/main/java/arekkuusu/solar/common/block/BlockQimranut.java
+++ b/src/main/java/arekkuusu/solar/common/block/BlockQimranut.java
@@ -119,7 +119,7 @@ public class BlockQimranut extends BlockBaseFacing {
 					.asImmutable()
 					.multiply(speed)
 					.rotate(x.multiply(z));
-			Solar.PROXY.spawnMute(world, back, speedVec, 45, 1F, 0x1BE564, Light.GLOW);
+			Solar.getProxy().spawnMute(world, back, speedVec, 45, 1F, 0x1BE564, Light.GLOW);
 		}
 	}
 

--- a/src/main/java/arekkuusu/solar/common/block/BlockQuartzConsumer.java
+++ b/src/main/java/arekkuusu/solar/common/block/BlockQuartzConsumer.java
@@ -57,7 +57,7 @@ public class BlockQuartzConsumer extends BlockBase {
 							.asImmutable()
 							.rotate(x.multiply(z))
 							.multiply(speed);
-					Solar.PROXY.spawnMute(world, posVec, speedVec, 45, 1.5F, 0x49FFFF, Light.GLOW);
+					Solar.getProxy().spawnMute(world, posVec, speedVec, 45, 1.5F, 0x49FFFF, Light.GLOW);
 				}
 			} else for(int i = 0; i < 3 + rand.nextInt(6); i++) {
 				Quat x = Quat.fromAxisAngle(Vector3.Forward(), (rand.nextFloat() * 2F - 1F) * 45);
@@ -67,7 +67,7 @@ public class BlockQuartzConsumer extends BlockBase {
 				Vector3 speedVec = Vector3.rotateRandom()
 						.multiply(speed)
 						.rotate(x.multiply(z));
-				Solar.PROXY.spawnMute(world, posVec.add(randVec), speedVec, 45, 0.5F, 0x49FFFF, Light.GLOW);
+				Solar.getProxy().spawnMute(world, posVec.add(randVec), speedVec, 45, 0.5F, 0x49FFFF, Light.GLOW);
 			}
 		});
 	}

--- a/src/main/java/arekkuusu/solar/common/block/BlockSchrodingerGlyph.java
+++ b/src/main/java/arekkuusu/solar/common/block/BlockSchrodingerGlyph.java
@@ -93,7 +93,7 @@ public class BlockSchrodingerGlyph extends BlockBase {
 			for(EnumFacing facing : EnumFacing.values()) {
 				Vector3 from = Vector3.Center().add(pos.getX(), pos.getY(), pos.getZ());
 				Vector3 vec = new Vector3.WrappedVec3i(facing.getDirectionVec()).asImmutable().multiply(0.025D);
-				Solar.PROXY.spawnNeutronBlast(world, from, vec, 60, 0.25F, 0xFF0303, false);
+				Solar.getProxy().spawnNeutronBlast(world, from, vec, 60, 0.25F, 0xFF0303, false);
 			}
 		}
 	}

--- a/src/main/java/arekkuusu/solar/common/block/tile/TileFissionInducer.java
+++ b/src/main/java/arekkuusu/solar/common/block/tile/TileFissionInducer.java
@@ -127,7 +127,7 @@ public class TileFissionInducer extends TileBase implements ITickable {
 				if(state.getBlock() == Blocks.GOLD_BLOCK || state.getBlock() == ModBlocks.MOLTEN_GOLD) {
 					Vector3 pos = new Vector3.WrappedVec3i(position.add(getPos())).asImmutable().add(Math.random(), 1.1D, Math.random());
 					Vector3 speed = Vector3.apply(0, 0.02, 0).multiply(world.rand.nextFloat());
-					Solar.PROXY.spawnDepthTunneling(world, pos, speed, 40, 3F, 0xff5000, GlowTexture.GLINT);
+					Solar.getProxy().spawnDepthTunneling(world, pos, speed, 40, 3F, 0xff5000, GlowTexture.GLINT);
 				}
 			}
 		}

--- a/src/main/java/arekkuusu/solar/common/block/tile/TileGravityHopper.java
+++ b/src/main/java/arekkuusu/solar/common/block/tile/TileGravityHopper.java
@@ -124,7 +124,7 @@ public class TileGravityHopper extends TileBase implements ITickable {
 			Vector3 speedVec = new Vector3.WrappedVec3i(facing.getDirectionVec())
 					.asImmutable()
 					.multiply(0.005D);
-			Solar.PROXY.spawnNeutronBlast(world, back, speedVec, 40, 0.25F, 0xFF0303, false);
+			Solar.getProxy().spawnNeutronBlast(world, back, speedVec, 40, 0.25F, 0xFF0303, false);
 		} else if(world.getTotalWorldTime() % 4 == 0 && world.rand.nextBoolean()) {
 			EnumFacing facing = getFacing().getOpposite();
 			Vector3 back = getOffSet(facing);
@@ -132,7 +132,7 @@ public class TileGravityHopper extends TileBase implements ITickable {
 			Vector3 speedVec = new Vector3.WrappedVec3i(facing.getDirectionVec())
 					.asImmutable()
 					.multiply(speed);
-			Solar.PROXY.spawnMute(world, back, speedVec, 30, 2F, 0x49FFFF, Light.GLOW);
+			Solar.getProxy().spawnMute(world, back, speedVec, 30, 2F, 0x49FFFF, Light.GLOW);
 		}
 	}
 

--- a/src/main/java/arekkuusu/solar/common/block/tile/TileKondenzator.java
+++ b/src/main/java/arekkuusu/solar/common/block/tile/TileKondenzator.java
@@ -61,7 +61,7 @@ public class TileKondenzator extends TileSimpleLumenBase implements ITickable {
 							.asImmutable()
 							.rotate(x.multiply(z))
 							.multiply(speed);
-					Solar.PROXY.spawnMute(world, pos, speedVec, 75, 1.75F, 0x49FFFF, Light.GLOW);
+					Solar.getProxy().spawnMute(world, pos, speedVec, 75, 1.75F, 0x49FFFF, Light.GLOW);
 				}
 			}
 			if(isFacingGlass()) {
@@ -69,7 +69,7 @@ public class TileKondenzator extends TileSimpleLumenBase implements ITickable {
 				int amount = (int) ((float) progress.getTimer() * (0.15F * (1F - (float) progress.getMultiplier() / 6F)));
 				for(int i = 0; i < amount + world.rand.nextInt(4); i++) {
 					Vector3 posVec = new Vector3.WrappedVec3i(getProgressPos()).asImmutable().add(Math.random(), Math.random(), Math.random());
-					Solar.PROXY.spawnSpeck(world, posVec, Vector3.rotateRandom().multiply(0.01D), 45, world.rand.nextFloat(), 0x49FFFF, GlowTexture.GLOW);
+					Solar.getProxy().spawnSpeck(world, posVec, Vector3.rotateRandom().multiply(0.01D), 45, world.rand.nextFloat(), 0x49FFFF, GlowTexture.GLOW);
 				}
 			}
 		}

--- a/src/main/java/arekkuusu/solar/common/block/tile/TileLuminicMechanism.java
+++ b/src/main/java/arekkuusu/solar/common/block/tile/TileLuminicMechanism.java
@@ -72,7 +72,7 @@ public class TileLuminicMechanism extends TileBase implements ITickable {
 	private void makeParticles(EnumFacing facing) {
 		Vector3 offset = new Vector3.WrappedVec3i(facing.getDirectionVec()).asImmutable().multiply(0.05D);
 		Vector3 from = new Vector3.WrappedVec3i(pos).asImmutable().add(0.5D);
-		Solar.PROXY.spawnNeutronBlast(world, from, offset, 120, 1F, 0xFFE077, true);
+		Solar.getProxy().spawnNeutronBlast(world, from, offset, 120, 1F, 0xFFE077, true);
 	}
 
 	public EnumFacing getFacingLazy() {

--- a/src/main/java/arekkuusu/solar/common/block/tile/TilePhotonContainer.java
+++ b/src/main/java/arekkuusu/solar/common/block/tile/TilePhotonContainer.java
@@ -91,8 +91,8 @@ public class TilePhotonContainer extends TileSimpleLumenBase implements ITickabl
 			Quat x = Quat.fromAxisAngle(Vector3.Forward(), (world.rand.nextFloat() * 2F - 1F) * 12F);
 			Quat z = Quat.fromAxisAngle(Vector3.Right(), (world.rand.nextFloat() * 2F - 1F) * 12F);
 			Vector3 speedVec = Vector3.rotateRandom().multiply(particleSpeed * world.rand.nextDouble()).rotate(x.multiply(z));
-			Solar.PROXY.spawnLuminescence(world, posVec, speedVec, 160, particleScale, GlowTexture.GLOW);
+			Solar.getProxy().spawnLuminescence(world, posVec, speedVec, 160, particleScale, GlowTexture.GLOW);
 		}
-		Solar.PROXY.spawnLuminescence(world, posVec, Vector3.Zero(), 160, particleScale, GlowTexture.GLOW);
+		Solar.getProxy().spawnLuminescence(world, posVec, Vector3.Zero(), 160, particleScale, GlowTexture.GLOW);
 	}
 }

--- a/src/main/java/arekkuusu/solar/common/block/tile/TileQuantumMirror.java
+++ b/src/main/java/arekkuusu/solar/common/block/tile/TileQuantumMirror.java
@@ -45,7 +45,7 @@ public class TileQuantumMirror extends TileQuantumInventoryBase implements ITick
 	public void update() {
 		if(world.isRemote && world.rand.nextInt(10) == 0) {
 			Vector3 from = Vector3.Center().add(pos.getX(), pos.getY(), pos.getZ());
-			Solar.PROXY.spawnSpeck(world, from, Vector3.rotateRandom().multiply(0.1F), 20, 0.1F, 0XFFFFFF, GlowTexture.STAR);
+			Solar.getProxy().spawnSpeck(world, from, Vector3.rotateRandom().multiply(0.1F), 20, 0.1F, 0XFFFFFF, GlowTexture.STAR);
 		}
 		if(!world.isRemote && dirty) {
 			getKey().ifPresent(uuid -> {

--- a/src/main/java/arekkuusu/solar/common/block/tile/TileVacuumConveyor.java
+++ b/src/main/java/arekkuusu/solar/common/block/tile/TileVacuumConveyor.java
@@ -114,7 +114,7 @@ public class TileVacuumConveyor extends TileBase implements ITickable {
 				.asImmutable()
 				.rotate(x.multiply(z))
 				.multiply(speed);
-		Solar.PROXY.spawnSpeck(world, back, speedVec, 75, 1.75F, inverse ? 0xFFFFFF : 0x000000, GlowTexture.GLINT);
+		Solar.getProxy().spawnSpeck(world, back, speedVec, 75, 1.75F, inverse ? 0xFFFFFF : 0x000000, GlowTexture.GLINT);
 	}
 
 	private void collectItems() {

--- a/src/main/java/arekkuusu/solar/common/entity/EntityEyeOfSchrodinger.java
+++ b/src/main/java/arekkuusu/solar/common/entity/EntityEyeOfSchrodinger.java
@@ -76,7 +76,7 @@ public class EntityEyeOfSchrodinger extends EntityMob {
 		//Spawn Particles
 		if(world.isRemote) {
 			int rgb = hasTargetedEntity() ? RED : BLUE;
-			Solar.PROXY.spawnDepthTunneling(world
+			Solar.getProxy().spawnDepthTunneling(world
 					, Vector3.apply(posX, posY + 0.25D, posZ)
 					, Vector3.Zero(), 10, 1.5F, rgb, GlowTexture.GLOW);
 			Entity entity = getTargetedEntity();
@@ -88,7 +88,7 @@ public class EntityEyeOfSchrodinger extends EntityMob {
 				if(speed.x() > 0.15D || speed.x() < -0.15D) speed.setX(0.15);
 				if(speed.y() > 0.15D || speed.y() < -0.15D) speed.setY(0.15);
 				if(speed.z() > 0.15D || speed.z() < -0.15D) speed.setZ(0.15);
-				Solar.PROXY.spawnSquared(world, Vector3.apply(posX, posY + 0.25D, posZ), speed.asImmutable(), 10, 4F, RED);
+				Solar.getProxy().spawnSquared(world, Vector3.apply(posX, posY + 0.25D, posZ), speed.asImmutable(), 10, 4F, RED);
 			}
 		}
 	}

--- a/src/main/java/arekkuusu/solar/common/entity/EntityLumen.java
+++ b/src/main/java/arekkuusu/solar/common/entity/EntityLumen.java
@@ -59,7 +59,7 @@ public class EntityLumen extends Entity {
 				Quat x = Quat.fromAxisAngle(Vector3.Forward(), (world.rand.nextFloat() * 2F - 1F) * 25F);
 				Quat z = Quat.fromAxisAngle(Vector3.Right(), (world.rand.nextFloat() * 2F - 1F) * 25F);
 				Vector3 vec = Vector3.apply(motionX, motionY, motionZ).rotate(x.multiply(z)).multiply(0.1D);
-				Solar.PROXY.spawnLuminescence(world, pos, vec, 30 + world.rand.nextInt(40), scale, GlowTexture.GLINT);
+				Solar.getProxy().spawnLuminescence(world, pos, vec, 30 + world.rand.nextInt(40), scale, GlowTexture.GLINT);
 			}
 		} else {
 			double drag = 0.128D;

--- a/src/main/java/arekkuusu/solar/common/entity/ModEntities.java
+++ b/src/main/java/arekkuusu/solar/common/entity/ModEntities.java
@@ -29,11 +29,11 @@ public final class ModEntities {
 	}
 
 	private static <T extends Entity> void register(Class<T> clazz, String name) {
-		EntityRegistry.registerModEntity(getLocation(name), clazz, name, id++, Solar.INSTANCE, 64, 1, true);
+		EntityRegistry.registerModEntity(getLocation(name), clazz, name, id++, Solar.getInstance(), 64, 1, true);
 	}
 
 	private static <T extends Entity> void register(Class<T> clazz, String name, int color) {
-		EntityRegistry.registerModEntity(getLocation(name), clazz, name, id++, Solar.INSTANCE, 64, 1, true, color, color);
+		EntityRegistry.registerModEntity(getLocation(name), clazz, name, id++, Solar.getInstance(), 64, 1, true, color, color);
 	}
 
 	private static ResourceLocation getLocation(String name) {


### PR DESCRIPTION
- Finalizing classes is good practise for types that you do not intend to have extended. This is especially good practise for singleton classes - see below - that should only ever have one implementation of themselves at compile time and/or runtime.
- Exposing the mutable proxy field is bad practise and design, and should be handle with [encapsulation](https://www.tutorialspoint.com/java/java_encapsulation.htm) of the reference. This PR replaces your `public` proxy field with a `private` one, pair with a `public` getter. All usages of the proxy have been updated for the encapsulation design.
- Migrating to `Mod$InstanceFactory` allows you full control over your mod instance, rather than relying on a reflectively assigned mutable field. This PR suggests an implementation of an eagerly loaded singleton, i.e a `private static final` instance in the root of the class, paired with a `private` constructor.